### PR TITLE
Memory leak fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,6 @@ wheels/
 *.egg
 MANIFEST
 
-build.bat
-staging/
-
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
@@ -105,3 +102,9 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+
+# ========
+build.bat
+staging/
+.idea/

--- a/ch_trees/gui.py
+++ b/ch_trees/gui.py
@@ -82,8 +82,7 @@ class TreeGen(bpy.types.Operator):
     def execute(self, context):
         # "Generate Tree" button callback
 
-        thread = threading.Thread(target=self._construct, kwargs={'context': context})
-        thread.start()
+        threading.Thread(daemon=True, target=self._construct, kwargs={'context': context}).start()
 
         return {'FINISHED'}
 


### PR DESCRIPTION
Generation thread was never getting terminated, which resulted in a memory-hogging zombie process graveyard. Remedied by daemonizing the threads and removing their reference (not storing the thread in a variable). Much faster and easier than checking for execution completion and manually terminating the thread.