### PR TITLE
Change name, conversion operator, "utilities" submenu containing mesh conversion operator

### DIFF
--- a/ch_trees/__init__.py
+++ b/ch_trees/__init__.py
@@ -16,6 +16,8 @@ def register():
     bpy.utils.register_class(gui.TreeGen)
     bpy.utils.register_class(gui.TreeGenPanel)
     bpy.utils.register_class(gui.TreeGenCustomisePanel)
+    bpy.utils.register_class(gui.TreeGenUtilitiesPanel)
+    bpy.utils.register_class(gui.TreeGenConvertToMesh)
     bpy.utils.register_class(gui.TreeGenSaveFile)
     bpy.utils.register_class(gui.TreeGenLoadParams)
 
@@ -24,6 +26,8 @@ def unregister():
     # Reversing order is best-practice
     bpy.utils.unregister_class(gui.TreeGenLoadParams)
     bpy.utils.unregister_class(gui.TreeGenSaveFile)
+    bpy.utils.unregister_class(gui.TreeGenConvertToMesh)
+    bpy.utils.unregister_class(gui.TreeGenUtilitiesPanel)
     bpy.utils.unregister_class(gui.TreeGenCustomisePanel)
     bpy.utils.unregister_class(gui.TreeGenPanel)
     bpy.utils.unregister_class(gui.TreeGen)

--- a/ch_trees/gui.py
+++ b/ch_trees/gui.py
@@ -242,10 +242,10 @@ class TreeGenConvertToMesh(bpy.types.Operator):
     bl_category = "TreeGen"
     bl_label = "Convert To Mesh"
     bl_options = {'REGISTER'}
-    
+
     def execute(self, context):
         from . import utilities
-        
+
         # update_log doesn't get a chance to print before Blender locks up, so a direct print is necessary
         sys.stdout.write('\nConverting tree to mesh. Blender will appear to crash; be patient.\n')
         sys.stdout.flush()
@@ -259,10 +259,10 @@ class TreeGenConvertToMesh(bpy.types.Operator):
         except Exception:
             update_log('\n{}\n'.format(traceback.format_exc()))
             update_log('Conversion to mesh failed\n\n')
-        
+
         return {'FINISHED'}
 
-                    
+
 class TreeGenSaveFile(bpy.types.Operator):
     """Button to save custom tree parameters"""
 

--- a/ch_trees/utilities.py
+++ b/ch_trees/utilities.py
@@ -61,7 +61,7 @@ def object_deleted(o):
         return True
 
 
-def simplify_branch_geometry(context, angle_limit=1.5):
+def convert_to_mesh(context, angle_limit=1.5):
     """
     Converts tree branches from curve to mesh, then runs a limited dissolve
     to reduce their geometric complexity with minimal quality loss.
@@ -75,7 +75,7 @@ def simplify_branch_geometry(context, angle_limit=1.5):
     try:
         tree = scene.objects.active
     except AttributeError:
-        raise Exception('Could not find tree while attempting to simplify branch geometry')
+        raise Exception('Could not find tree while attempting to convert to mesh')
 
     old_branches = None
     for child in tree.children:
@@ -84,7 +84,7 @@ def simplify_branch_geometry(context, angle_limit=1.5):
             break
 
     if old_branches is None:
-        raise Exception('No branches found while simplifying branch geometry')
+        raise Exception('No branches found while converting to mesh')
 
     # Convert the branches curve to a mesh, then get an editable copy
     old_branch_mesh = old_branches.to_mesh(scene, False, 'RENDER')


### PR DESCRIPTION
Did a little bit more than just change the name. I moved the code for mesh conversion into its own operator so that it can easily be called after the tree has already been generated. Additionally, I've added a utilities submenu where we can put more post-generation utilities.

I think this is a huge benefit because it allows the user to play around with the branch curve before converting it to a mesh (and without having to figure out converting to a mesh on their own).

It will also creates a spot for a new feature I'd like to add: automated LOD (level of detail) generation for use in game engines.