### PR TITLE
Remove primary execution thread in Blender 2.8

### DIFF
--- a/ch_trees/__init__.py
+++ b/ch_trees/__init__.py
@@ -5,7 +5,7 @@ bl_info = {
     "author": "Charlie Hewitt and Luke Pflibsen-Jones",
     "version": (0, 0, 1),
     "wiki_url": "https://github.com/friggog/tree-gen/wiki",
-    'blender': (2, 70, 0)
+    'blender': (2, 80, 0)
 }
 
 

--- a/ch_trees/gui.py
+++ b/ch_trees/gui.py
@@ -499,7 +499,7 @@ class TreeGenCustomisePanel(bpy.types.Panel):
                 cont.prop(scene, prop, text=label)
 
         row = layout.row()
-        row.label(text = "Leaf Parameters:")
+        row.label(text="Leaf Parameters:")
         box = layout.box()
         box.row()
         label_row('', 'generate_leaves_input', checkbox=True, container=box)
@@ -517,7 +517,7 @@ class TreeGenCustomisePanel(bpy.types.Panel):
 
         layout.separator()
         row = layout.row()
-        row.label(text = "Tree Parameters:")
+        row.label(text="Tree Parameters:")
         box = layout.box()
         box.row()
         label_row('Tree Shape', 'tree_shape_input', dropdown=True, container=box)
@@ -544,7 +544,7 @@ class TreeGenCustomisePanel(bpy.types.Panel):
 
         layout.separator()
         row = layout.row()
-        row.label(text = "Branch Parameters:")
+        row.label(text="Branch Parameters:")
         box = layout.box()
         box.row()
         label_row('Number', 'tree_branches_input', container=box)

--- a/ch_trees/gui.py
+++ b/ch_trees/gui.py
@@ -1,7 +1,6 @@
 import bpy
 
 import traceback
-import threading
 import sys
 import importlib
 import os
@@ -196,7 +195,7 @@ class TreeGen(bpy.types.Operator):
         bpy.ops.object.treegen_main_thread_executer()
 
         params = TreeGen.get_params_from_customizer(context)
-        threading.Thread(daemon=True, target=self._construct, kwargs={'context': context, 'params': params, 'callback_queue': main_thread_callback_queue}).start()
+        self._construct(context, params, main_thread_callback_queue)
 
         return {'FINISHED'}
 
@@ -422,7 +421,7 @@ class TreeGenLoadParams(bpy.types.Operator):
 
 class TreeGenMainThreadExecuter(bpy.types.Operator):
     # Internal utility that handles executing tasks on the main thread.
-    # Necessary LOD creation
+    # Necessary for LOD creation
 
     bl_idname = 'object.treegen_main_thread_executer'
     bl_label = 'TreeGen internal executer utility'

--- a/ch_trees/gui.py
+++ b/ch_trees/gui.py
@@ -227,7 +227,11 @@ class TreeGen(bpy.types.Operator):
                 return
 
             start_time = time.time()
-            parametric.gen.construct(params, scene.seed_input, scene.generate_leaves_input)
+            tree = parametric.gen.construct(params, scene.seed_input, scene.generate_leaves_input)
+            for o in context.view_layer.objects:
+                o.select_set(False)
+            tree.select_set(True)
+            context.view_layer.objects.active = tree
 
             if scene.render_input:
                 callback_queue.put(bpy.ops.object.tree_gen_render_tree)

--- a/ch_trees/parametric/gen.py
+++ b/ch_trees/parametric/gen.py
@@ -321,7 +321,7 @@ class Tree(object):
             leaf_uv = base_leaf_shape[2]
 
             if leaf_uv:
-                leaves.uv_textures.new("leavesUV")
+                leaves.uv_layers.new(name="leavesUV")
                 uv_layer = leaves.uv_layers.active.data
 
                 for seg_ind in range(int(len(leaf_faces) / len(base_leaf_shape[1]))):

--- a/ch_trees/parametric/gen.py
+++ b/ch_trees/parametric/gen.py
@@ -1244,7 +1244,11 @@ def construct(params, seed=0, generate_leaves=True):
     t = Tree(TreeParam(params), generate_leaves)
     t.make()
 
+    ret_obj = t.tree_obj
+
     # Try to get unneeded data out of memory ASAP
     del t.leaves_array
     del t.branches_curve
     del t
+
+    return ret_obj

--- a/ch_trees/utilities.py
+++ b/ch_trees/utilities.py
@@ -168,7 +168,7 @@ def generate_lods(context, level_count=3):
 
         bpy.ops.object.modifier_apply(modifier='TreeDecimateMod')
         new_branches.select_set(True)
-        new_branches.hide_viewport = True
+        new_branches.hide_set(True)
 
         # Purge old data from memory
         bpy.data.curves.remove(new_curve.data)
@@ -227,7 +227,7 @@ def _generate_leaf_lods(context, level_count=3):
             new_leaf_data.faces.ensure_lookup_table()
             to_delete = [new_leaf_data.faces[i] for i in indexes_to_delete]
 
-            bmesh.ops.delete(new_leaf_data, geom=list(to_delete))
+            bmesh.ops.delete(new_leaf_data, geom=list(to_delete), context='FACES')
 
         # Create new leaves object and copy the new leaves data into it
         lod_level_name = '_LOD' + str(level + 1)
@@ -239,7 +239,7 @@ def _generate_leaf_lods(context, level_count=3):
         context.collection.objects.link(new_leaves)
         new_leaves.matrix_world = parent.matrix_world
         new_leaves.parent = parent
-        new_leaves.hide_viewport = True
+        new_leaves.hide_set(True)
 
         update_log('\rLeaf LOD level ' + str(level + 1) + '/' + str(level_count) + ' generated')
 


### PR DESCRIPTION
Until thread-safety is officially supported by Blender (or we find another hacky work-around), this is the only way to get the addon working reliably (eg, no memory access violation crashes). This unfortunately means that the Blender GUI will freeze while generation is in progress, and updates on progress will need to be observed via the console :(