### PR TITLE
Improve performance and reduce memory footprint during generation of complex trees

### DIFF
--- a/chturtle.py
+++ b/chturtle.py
@@ -31,18 +31,25 @@ class Vector(mathutils.Vector):
 class CHTurtle(object):
     """3D turtle implementation for use in both L-Systems and Parametric tree
     generation schemes"""
-    dir = Vector([0.0, 0.0, 1.0])
-    pos = Vector([0.0, 0.0, 0.0])
-    right = Vector([1.0, 0.0, 0.0])
-    width = 0.0
+
+    __slots__ = (
+        'dir', 'pos', 'right', 'width'
+    )
 
     def __init__(self, other=None):
         """Copy Constructor"""
+
         if other is not None:
             self.dir = other.dir.copy()
             self.pos = other.pos.copy()
             self.right = other.right.copy()
             self.width = other.width
+
+        else:
+            self.dir = Vector([0.0, 0.0, 1.0])
+            self.pos = Vector([0.0, 0.0, 0.0])
+            self.right = Vector([1.0, 0.0, 0.0])
+            self.width = 0.0
 
     def __str__(self):
         return 'Turtle at %s, direction %s, right %s' % (self.pos, self.dir, self.right)

--- a/leaf.py
+++ b/leaf.py
@@ -10,9 +10,10 @@ from .  import leaf_shapes as leaf_geom
 
 class Leaf(object):
     """Class to store data for each leaf in the system"""
-    position = None
-    direction = None
-    right = None
+
+    __slots__ = (
+        'position', 'direction', 'right'
+    )
 
     def __init__(self, pos, direction, right):
         """Init method for leaf with position, direction and relative x axis"""

--- a/parametric/gen.py
+++ b/parametric/gen.py
@@ -116,23 +116,25 @@ class BranchMode(Enum):
 class Stem(object):
     """Class to store data for each stem (branch) in the system, primarily to
     be accessed by its children in calculating their own parameters"""
-    depth = 0
-    children = []
-    parent = None
-    curve = None
-    length = 0
-    offset = 0
-    radius = 0
-    length_child_max = 0
-    radius_limit = 0
+
+    __slots__ = (
+        'depth', 'curve', 'parent', 'offset', 'radius_limit', 'children', 'length', 'radius',
+        'length_child_max'
+    )
 
     def __init__(self, depth, curve, parent=None, offset=0, radius_limit=-1):
         """Init with at depth with curve, possibly parent and offset (for depth > 0)"""
+
         self.depth = depth
         self.curve = curve
         self.parent = parent
         self.offset = offset
         self.radius_limit = radius_limit
+
+        self.children = []
+        self.length = 0
+        self.radius = 0
+        self.length_child_max = 0
 
     def copy(self):
         """Copy method for stems"""
@@ -148,21 +150,26 @@ class Stem(object):
 
 class Tree(object):
     """Class to store data for the tree"""
-    tree_scale = 0
-    param = None
-    leaves_array = None
-    branches_curve = None
-    base_length = 0
-    split_num_error = [0, 0, 0, 0, 0, 0, 0]
-    tree_obj = None
-    trunk_length = 0
+
+    __slots__ = (
+        'param', 'generate_leaves', 'leaves_array', 'stem_index', 'tree_scale', 'branches_curve',
+        'base_length', 'split_num_error', 'tree_obj', 'trunk_length'
+    )
 
     def __init__(self, param, generate_leaves=True):
         """initialize tree with specified parameters"""
+
         self.param = param
         self.generate_leaves = generate_leaves
         self.leaves_array = []
+
         self.stem_index = 0
+        self.tree_scale = 0
+        self.branches_curve = None
+        self.base_length = 0
+        self.split_num_error = [0, 0, 0, 0, 0, 0, 0]
+        self.tree_obj = None
+        self.trunk_length = 0
 
         # Disable leaf generation
         if not generate_leaves:


### PR DESCRIPTION
Since we don't dynamically add instance variables to objects during runtime, we can leverage `__slots__` to remove the `Leaf`, `Stem`, and `Tree` classes' `__dict__` attribute. This reduces memory requirements and increases performance on complex trees. Really doesn't make a difference for `Tree`, but I added anyway for consistency.

It doesn't make a difference in simple trees, but in complex trees like the Weeping Willow that have boatloads of branches and leaves it makes a significant difference. My tests show it shaves off about 11 seconds from generating a Weeping Willow while making no statistically significant difference for Black Oak.

I have apparently lost the memory benchmarks from these runs (I did them a while back), but since this removes the `__dict__` attribute from each class it's not possible for the footprint to be worse.


W/O `__slots__`

Tree: Black Oak
Seed: 8684998

Avg of 4 runs:
create_branches: 3.99 seconds
create_leaf_mesh: 7.77 seconds
Tree generated in 11.75 seconds


Tree: Weeping Willow
Seed: 8684998

Avg of 4 runs:
create_branches: 76.21 seconds
create_leaf_mesh: 18.00 seconds
Tree generated in 93.86 seconds

====

`__slots__`

Tree: Black Oak
Seed: 8684998

Avg of 4 runs:
create_branches: 4.01 seconds
create_leaf_mesh: 8.00 seconds
Tree generated in 11.78 seconds


Tree: Weeping Willow
Seed: 8684998

Avg of 4 runs:
create_branches: 65.62 seconds
create_leaf_mesh: 16.95 seconds
Tree generated in 82.26 seconds